### PR TITLE
Add simple RCPSP scheduler package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# RCPSP Scheduler
+
+Example project implementing a simple resource-constrained project scheduling problem solver using OR-Tools.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import argparse
+
+from scheduler import load_json, Scheduler, write_schedule
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run RCPSP scheduler")
+    parser.add_argument("input", type=Path, help="Input JSON file")
+    parser.add_argument("output", type=Path, help="Output JSON file")
+    args = parser.parse_args()
+
+    tasks, resources, _ = load_json(args.input)
+    sched = Scheduler(tasks, resources)
+    schedule = sched.solve()
+    write_schedule(args.output, tasks, schedule)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rcpsp-scheduler"
+version = "0.1.0"
+description = "Simple RCPSP scheduler"
+authors = [ { name = "Example" } ]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "ortools>=9.9"
+]
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/scheduler/__init__.py
+++ b/scheduler/__init__.py
@@ -1,0 +1,8 @@
+"""Simple RCPSP scheduler package."""
+
+from .data import Task, Resource, Calendar
+from .parser import load_json
+from .scheduler import Scheduler
+from .output import write_schedule
+
+__all__ = ["Task", "Resource", "Calendar", "load_json", "Scheduler", "write_schedule"]

--- a/scheduler/data.py
+++ b/scheduler/data.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Task:
+    """A project task."""
+
+    id: str
+    duration: int
+    demands: Dict[str, int] = field(default_factory=dict)
+    predecessors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Resource:
+    """A renewable resource with limited capacity."""
+
+    id: str
+    capacity: int
+
+
+@dataclass
+class Calendar:
+    """Simple working calendar."""
+
+    id: str
+    working_hours: int = 8

--- a/scheduler/output.py
+++ b/scheduler/output.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .data import Task
+
+
+def write_schedule(path: Path, tasks: List[Task], schedule: Dict[str, Dict[str, int]]) -> None:
+    """Write schedule to JSON file."""
+    data = {
+        "schedule": [
+            {"id": t.id, "start": schedule[t.id]["start"], "end": schedule[t.id]["end"]}
+            for t in tasks
+        ]
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/scheduler/parser.py
+++ b/scheduler/parser.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from typing import List
+
+from .data import Task, Resource, Calendar
+
+
+def load_json(path: Path) -> tuple[List[Task], List[Resource], List[Calendar]]:
+    """Load tasks, resources and calendars from a JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    tasks = [
+        Task(
+            id=t["id"],
+            duration=t["duration"],
+            demands=t.get("demands", {}),
+            predecessors=t.get("predecessors", []),
+        )
+        for t in data.get("tasks", [])
+    ]
+
+    resources = [Resource(id=r["id"], capacity=r["capacity"]) for r in data.get("resources", [])]
+
+    calendars = [
+        Calendar(id=c.get("id"), working_hours=c.get("working_hours", 8))
+        for c in data.get("calendars", [])
+    ]
+
+    return tasks, resources, calendars

--- a/scheduler/scheduler.py
+++ b/scheduler/scheduler.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ortools.sat.python import cp_model
+
+from .data import Task, Resource
+
+
+class Scheduler:
+    """Solve RCPSP using CP-SAT."""
+
+    def __init__(self, tasks: List[Task], resources: List[Resource]):
+        self.tasks = tasks
+        self.resources = resources
+
+    def solve(self) -> Dict[str, Dict[str, int]]:
+        model = cp_model.CpModel()
+        horizon = sum(t.duration for t in self.tasks)
+
+        starts = {}
+        ends = {}
+        intervals = {}
+        for task in self.tasks:
+            start = model.NewIntVar(0, horizon, f"start_{task.id}")
+            end = model.NewIntVar(0, horizon, f"end_{task.id}")
+            interval = model.NewIntervalVar(start, task.duration, end, f"interval_{task.id}")
+            starts[task.id] = start
+            ends[task.id] = end
+            intervals[task.id] = interval
+
+        # Precedence constraints
+        for task in self.tasks:
+            for pred in task.predecessors:
+                model.Add(starts[task.id] >= ends[pred])
+
+        # Resource constraints
+        for res in self.resources:
+            demands = []
+            ivs = []
+            for task in self.tasks:
+                if res.id in task.demands:
+                    demands.append(task.demands[res.id])
+                    ivs.append(intervals[task.id])
+            if ivs:
+                model.AddCumulative(ivs, demands, res.capacity)
+
+        makespan = model.NewIntVar(0, horizon, "makespan")
+        model.AddMaxEquality(makespan, [ends[t.id] for t in self.tasks])
+        model.Minimize(makespan)
+
+        solver = cp_model.CpSolver()
+        result = solver.Solve(model)
+
+        schedule = {}
+        if result in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+            for t in self.tasks:
+                schedule[t.id] = {
+                    "start": solver.Value(starts[t.id]),
+                    "end": solver.Value(ends[t.id]),
+                }
+        return schedule


### PR DESCRIPTION
## Summary
- initialize Python package `scheduler`
- add dependency management via `pyproject.toml`
- implement dataclasses for project data
- parse JSON input for tasks and resources
- create CP-SAT scheduling model
- generate JSON output and CLI entry point

## Testing
- `python3 -m compileall -q scheduler main.py`
- `pip install ortools` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e6b51a77c8331b4961fb4b79aa34f