### PR TITLE
Add pytest suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ dependencies = [
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+import importlib.util
+import types
+import sys
+
+package_path = Path(__file__).resolve().parents[1] / "scheduler"
+pkg = types.ModuleType("scheduler")
+pkg.__path__ = [str(package_path)]
+sys.modules.setdefault("scheduler", pkg)
+
+_spec = importlib.util.spec_from_file_location(
+    "scheduler.parser",
+    package_path / "parser.py",
+)
+parser = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(parser)
+load_json = parser.load_json
+
+def test_parse_global_and_resource_calendars(tmp_path: Path):
+    data = {
+        "tasks": [],
+        "resources": [],
+        "calendars": [
+            {"id": "global", "working_hours": 6},
+            {"id": "machine", "working_hours": 10}
+        ]
+    }
+    file = tmp_path / "input.json"
+    file.write_text(json.dumps(data))
+
+    _, _, calendars = load_json(file)
+
+    assert len(calendars) == 2
+    ids = {c.id for c in calendars}
+    assert {"global", "machine"} == ids
+    hours = {c.id: c.working_hours for c in calendars}
+    assert hours["global"] == 6
+    assert hours["machine"] == 10

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+import importlib.util
+import types
+import sys
+
+package_path = Path(__file__).resolve().parents[1] / "scheduler"
+pkg = types.ModuleType("scheduler")
+pkg.__path__ = [str(package_path)]
+sys.modules.setdefault("scheduler", pkg)
+
+_spec = importlib.util.spec_from_file_location(
+    "scheduler.parser",
+    package_path / "parser.py",
+)
+parser = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(parser)
+load_json = parser.load_json
+
+def test_load_json_with_hierarchy(tmp_path: Path):
+    data = {
+        "tasks": [
+            {"id": "A", "duration": 2},
+            {"id": "B", "duration": 3, "predecessors": ["A"]}
+        ],
+        "resources": [{"id": "r1", "capacity": 2}],
+        "calendars": [{"id": "global", "working_hours": 8}]
+    }
+    file = tmp_path / "input.json"
+    file.write_text(json.dumps(data))
+
+    tasks, resources, calendars = load_json(file)
+
+    assert len(tasks) == 2
+    assert tasks[1].predecessors == ["A"]
+    assert resources[0].id == "r1"
+    assert calendars[0].id == "global"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,20 @@
+import pytest
+
+pytest.importorskip("ortools")
+
+from scheduler import Task, Resource, Scheduler
+
+
+def test_schedule_respects_precedence_and_resources():
+    tasks = [
+        Task(id="T1", duration=2, demands={"res": 1}),
+        Task(id="T2", duration=2, demands={"res": 1}, predecessors=["T1"]),
+    ]
+    resources = [Resource(id="res", capacity=1)]
+
+    sched = Scheduler(tasks, resources)
+    schedule = sched.solve()
+
+    assert schedule["T2"]["start"] >= schedule["T1"]["end"]
+    assert schedule["T1"]["end"] - schedule["T1"]["start"] == 2
+    assert schedule["T2"]["end"] - schedule["T2"]["start"] == 2


### PR DESCRIPTION
## Summary
- add pytest configuration to `pyproject.toml`
- create basic parsing and scheduling tests
- ensure scheduler tests skip when ortools is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6e5a9260833184e5fce1678c12a6