### PR TITLE
Add default args and visualization hook

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,19 +1,41 @@
 from pathlib import Path
 import argparse
+import subprocess
+import sys
 
 from scheduler import load_json, Scheduler, write_schedule
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run RCPSP scheduler")
-    parser.add_argument("input", type=Path, help="Input JSON file")
-    parser.add_argument("output", type=Path, help="Output JSON file")
+    parser.add_argument("input", type=Path, nargs="?", help="Input JSON file")
+    parser.add_argument("output", type=Path, nargs="?", help="Output JSON file")
     args = parser.parse_args()
 
-    tasks, resources, _ = load_json(args.input)
+    input_path = args.input
+    output_path = args.output
+
+    if input_path is None and output_path is None:
+        default_in = Path("input.json")
+        if default_in.exists():
+            input_path = default_in
+            output_path = Path("output.json")
+        else:
+            parser.error("input file is required")
+    elif input_path is None or output_path is None:
+        parser.error("both input and output files must be specified")
+
+    tasks, resources, _ = load_json(input_path)
     sched = Scheduler(tasks, resources)
     schedule = sched.solve()
-    write_schedule(args.output, tasks, schedule)
+    write_schedule(output_path, tasks, schedule)
+
+    visualize_script = Path(__file__).with_name("visualize.py")
+    if visualize_script.exists():
+        subprocess.run(
+            [sys.executable, str(visualize_script), str(output_path)],
+            check=False,
+        )
 
 
 if __name__ == "__main__":

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+import argparse
+
+
+def visualize(path: Path) -> None:
+    """Simple visualization of the schedule."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    for item in data.get("schedule", []):
+        print(f"Task {item['id']} : start={item['start']} end={item['end']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Visualize RCPSP schedule")
+    parser.add_argument("schedule", type=Path, help="Schedule JSON file")
+    args = parser.parse_args()
+    visualize(args.schedule)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support optional input/output arguments in `main.py`
- fallback to `input.json` and `output.json` if they exist when no args are given
- invoke `visualize.py` automatically after creating the schedule
- provide basic `visualize.py` script for printing the schedule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e736b2a048331bc49f686aac89948