### PR TITLE
Add HTML visualization

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def main() -> None:
     tasks, resources, _ = load_json(input_path)
     sched = Scheduler(tasks, resources)
     schedule = sched.solve()
-    write_schedule(output_path, tasks, schedule)
+    write_schedule(output_path, tasks, schedule, resources)
 
     visualize_script = Path(__file__).with_name("visualize.py")
     if visualize_script.exists():

--- a/scheduler/output.py
+++ b/scheduler/output.py
@@ -2,16 +2,45 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
-from .data import Task
+from .data import Task, Resource
 
 
-def write_schedule(path: Path, tasks: List[Task], schedule: Dict[str, Dict[str, int]]) -> None:
-    """Write schedule to JSON file."""
+def write_schedule(
+    path: Path,
+    tasks: List[Task],
+    schedule: Dict[str, Dict[str, int]],
+    resources: List[Resource] | None = None,
+) -> None:
+    """Write schedule along with task and resource info to JSON file."""
+
     data = {
-        "schedule": [
-            {"id": t.id, "start": schedule[t.id]["start"], "end": schedule[t.id]["end"]}
+        "tasks": [
+            {
+                "id": t.id,
+                "duration": t.duration,
+                "demands": t.demands,
+                "predecessors": t.predecessors,
+            }
             for t in tasks
-        ]
+        ],
+        "schedule": [
+            {
+                "id": t.id,
+                "start": schedule[t.id]["start"],
+                "end": schedule[t.id]["end"],
+            }
+            for t in tasks
+        ],
     }
+
+    if resources is not None:
+        data["resources"] = [
+            {
+                "id": r.id,
+                "capacity": r.capacity,
+            }
+            for r in resources
+        ]
+
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)

--- a/visualize.py
+++ b/visualize.py
@@ -1,21 +1,107 @@
+"""Generate an HTML visualization for a schedule."""
+
+from __future__ import annotations
+
 import json
 from pathlib import Path
 import argparse
 
 
-def visualize(path: Path) -> None:
-    """Simple visualization of the schedule."""
-    with open(path, "r", encoding="utf-8") as f:
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RCPSP Schedule</title>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <style>
+    body { font-family: sans-serif; }
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #999; padding: 4px; text-align: center; }
+    .task-cell { background-color: #cde; }
+  </style>
+</head>
+<body>
+  <div>
+    <button id="zoom-in">Zoom In</button>
+    <button id="zoom-out">Zoom Out</button>
+  </div>
+  <div id="table-container"></div>
+  <script>
+  const data = __DATA__;
+  const tasks = data.tasks || [];
+  const resources = data.resources || [];
+  const scheduleMap = {};
+  (data.schedule || []).forEach(d => scheduleMap[d.id] = d);
+
+  const horizon = d3.max(data.schedule, d => d.end);
+  const days = d3.range(horizon);
+  const table = d3.select('#table-container').append('table');
+  const header = table.append('tr');
+  header.append('th').text('Resource');
+  days.forEach(d => header.append('th').text(d));
+
+  resources.forEach(res => {
+    const row = table.append('tr');
+    row.append('th').text(res.id);
+    let day = 0;
+    while (day < horizon) {
+      const task = tasks.find(t => t.demands && t.demands[res.id] && scheduleMap[t.id].start <= day && scheduleMap[t.id].end > day);
+      if (task) {
+        const start = day;
+        while (day < horizon && scheduleMap[task.id].start <= day && scheduleMap[task.id].end > day) {
+          day++;
+        }
+        const cell = row.append('td')
+          .attr('colspan', day - start)
+          .attr('class', 'task-cell')
+          .text(task.id);
+        cell.append('title')
+          .text(`${task.id}: ${scheduleMap[task.id].start} - ${scheduleMap[task.id].end} (${scheduleMap[task.id].end - scheduleMap[task.id].start} days)`);
+      } else {
+        row.append('td');
+        day += 1;
+      }
+    }
+  });
+
+  let scale = 1;
+  function updateZoom() {
+    d3.selectAll('td,th')
+      .style('font-size', (12 * scale) + 'px')
+      .style('min-width', (40 * scale) + 'px');
+  }
+  d3.select('#zoom-in').on('click', () => { scale *= 1.25; updateZoom(); });
+  d3.select('#zoom-out').on('click', () => { scale /= 1.25; updateZoom(); });
+  updateZoom();
+  </script>
+</body>
+</html>
+"""
+
+
+def visualize(json_path: Path, html_path: Path | None = None) -> None:
+    """Generate an HTML file from a schedule JSON."""
+    with open(json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
-    for item in data.get("schedule", []):
-        print(f"Task {item['id']} : start={item['start']} end={item['end']}")
+
+    html = HTML_TEMPLATE.replace("__DATA__", json.dumps(data))
+
+    if html_path is None:
+        html_path = json_path.with_suffix(".html")
+
+    with open(html_path, "w", encoding="utf-8") as out:
+        out.write(html)
+    print(f"Wrote visualization to {html_path}")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Visualize RCPSP schedule")
     parser.add_argument("schedule", type=Path, help="Schedule JSON file")
+    parser.add_argument(
+        "-o", "--output", type=Path, default=None, help="Output HTML file"
+    )
     args = parser.parse_args()
-    visualize(args.schedule)
+    visualize(args.schedule, args.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- output schedule along with task and resource metadata
- update CLI to pass resources to the output writer
- generate an HTML visualization with D3 and zoom buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7511c84c833185069599a47165e9